### PR TITLE
giddy 2.3.6 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/quantecon-feedstock/pr2/021daa9

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/quantecon-feedstock/pr2/021daa9
+  - https://staging.continuum.io/prefect/fs/esda-feedstock/pr5/d6bf73b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/esda-feedstock/pr5/d6bf73b

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,13 +15,6 @@ build:
     - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [py<310]
-  # Unable to build py313. 
-  # Trace:
-  # 1) ImportError: cannot import name 'np' from 'libpysal.common'
-  #     To fix that issue need to rebuild esda 2.5.1 for py313.
-  # 2) esda build fails because scipy >=1.9,<1.12 is not available on py313
-  # 3) Impossible to build scipy 1.12 with py3.13 (incompatible with pythran >0.16, meson-python >0.16, and numpy conflicts with openblas-devel)
-  skip: True  # [py>312]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,48 +1,61 @@
 {% set name = "giddy" %}
-{% set version = "2.3.3" %}
+{% set version = "2.3.6" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: af5e53e798564aea909f2efa0e177a0625ab2a230e23b05c0e8468242a90475c
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/giddy-{{ version }}.tar.gz
+  sha256: 004ec587eb7b75d9f717efd9b018a9f95f55d30d9768e2bb9cdb86ae7bdb7592
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  script_env:
+    - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<310]
 
 requirements:
   host:
-    - python >=3
+    - python
+    - wheel
+    - setuptools >=61.0
+    - setuptools-scm >=6.2
     - pip
   run:
-    - python >=3
-    - scipy >=1.3.0
-    - libpysal >=4.0.1
-    - mapclassify >=2.1.1
-    - esda >=2.1.1
-    - quantecon >=0.4.7
+    - python
+    - esda >=2.4
+    - libpysal >=4.8
+    - mapclassify >=2.5
+    - quantecon >=0.7
+    - scipy >=1.8
 
 test:
   imports:
     - giddy
+  commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest --pyargs giddy.tests  # [py<312]
+  requires:
+    - pip
+    - pytest
+    # To enable tests for py>312 need to rebuild split.
+    - splot  # [py<312]
 
 about:
-  home: http://pysal.org
+  home: https://pysal.org
+  summary: GeospatIal Distribution DYnamics (giddy) in PySAL
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt
-  summary: GeospatIal Distribution DYnamics (giddy) in PySAL
-
   description: |
     Giddy is an open-source python library for the analysis of dynamics of longitudinal spatial 
     data. Originating from the spatial dynamics module in PySAL (Python Spatial Analysis Library), 
     it is under active development for the inclusion of newly proposed analytics that consider the 
     role of space in the evolution of distributions over time.
-  doc_url: http://pysal.org/giddy
+  doc_url: https://pysal.org/giddy
   dev_url: https://github.com/pysal/giddy
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ test:
   requires:
     - pip
     - pytest
-    # To enable tests for py>312 need to rebuild split.
+    # To enable tests for py>312 need to rebuild splot.
     - splot  # [py<312]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,12 @@ build:
     - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [py<310]
+  # Unable to build py313. 
+  # Trace:
+  # 1) ImportError: cannot import name 'np' from 'libpysal.common'
+  #     To fix that issue need to rebuild esda 2.5.1 for py313.
+  # 2) esda build fails because scipy >=1.9,<1.12 is not available on py313, and we can`t build because of Cython build errors.
+  skip: True  # [py>312]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,8 @@ build:
   # Trace:
   # 1) ImportError: cannot import name 'np' from 'libpysal.common'
   #     To fix that issue need to rebuild esda 2.5.1 for py313.
-  # 2) esda build fails because scipy >=1.9,<1.12 is not available on py313, and we can`t build because of Cython build errors.
+  # 2) esda build fails because scipy >=1.9,<1.12 is not available on py313
+  # 3) Impossible to build scipy 1.12 with py3.13 (incompatible with pythran >0.16, meson-python >0.16, and numpy conflicts with openblas-devel)
   skip: True  # [py>312]
 
 requirements:


### PR DESCRIPTION
giddy 2.3.6 

**Destination channel:** Defaults

### Links

- [PKG-7817]
- dev_url:        https://github.com/pysal/giddy/tree/v2.3.6
- conda_forge:    https://github.com/conda-forge/giddy-feedstock
- pypi:           https://pypi.org/project/giddy/2.3.6
- pypi inspector: https://inspector.pypi.io/project/giddy/2.3.6

### Explanation of changes:

- new version number


[PKG-7817]: https://anaconda.atlassian.net/browse/PKG-7817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ